### PR TITLE
Plugin2 compatibility update

### DIFF
--- a/lib/Dancer2/Plugin/OAuth2/Server.pm
+++ b/lib/Dancer2/Plugin/OAuth2/Server.pm
@@ -40,7 +40,7 @@ on_plugin_import {
 };
 
 register 'oauth_scopes' => sub {
-    my ($dsl, $scopes, $code_ref) = plugin_args(@_);
+    my ($dsl, $scopes, $code_ref) = @_;
 
     my $settings = plugin_setting;
 
@@ -53,7 +53,7 @@ register 'oauth_scopes' => sub {
             $dsl->status( 400 );
             return $dsl->to_json( { error => $res[1] } );
         } else {
-            $dsl->var( oauth_access_token => $res[0] );
+            $dsl->app->request->var( oauth_access_token => $res[0] );
             goto $code_ref;
         }
     }


### PR DESCRIPTION
Minimal changes to remove deprecation warnings for new Plugin code.
- stop using `plugin_args`
- change `$dsl->var` to `$dsl->app->request->var`
