### PR TITLE
Use send_as and response_header keywords

### DIFF
--- a/META.json
+++ b/META.json
@@ -40,7 +40,7 @@
             "Carp" : "0",
             "Class::Load" : "0",
             "Crypt::PRNG" : "0",
-            "Dancer2" : "0.163000",
+            "Dancer2" : "0.200000",
             "Dancer2::Plugin" : "0",
             "MIME::Base64" : "0",
             "URI" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'perl', '5.008005';
 
-requires "Dancer2" => "0.163000";
+requires "Dancer2" => "0.200000";
 requires "Dancer2::Plugin";
 requires "Crypt::PRNG";
 requires "URI";

--- a/lib/Dancer2/Plugin/OAuth2/Server.pm
+++ b/lib/Dancer2/Plugin/OAuth2/Server.pm
@@ -51,7 +51,7 @@ register 'oauth_scopes' => sub {
         my @res = _verify_access_token_and_scope( $dsl, $settings, $server,0, @$scopes );
         if( not $res[0] ) {
             $dsl->status( 400 );
-            return $dsl->to_json( { error => $res[1] } );
+            return $dsl->send_as( JSON => { error => $res[1] } );
         } else {
             $dsl->app->request->var( oauth_access_token => $res[0] );
             goto $code_ref;
@@ -75,8 +75,8 @@ sub _authorization_request {
             or $type ne 'code'
     ) {
         $dsl->status( 400 );
-        return $dsl->to_json(
-            {
+        return $dsl->send_as(
+            JSON => {
                 error             => 'invalid_request',
                 error_description => 'the request was missing one of: client_id, '
                 . 'response_type;'
@@ -93,8 +93,8 @@ sub _authorization_request {
             and ! length $state
     ) {
         $dsl->status( 400 );
-        return $dsl->to_json(
-            {
+        return $dsl->send_as(
+            JSON => {
                 error             => 'invalid_request',
                 error_description => 'the request was missing : state ',
                 error_uri         => '',
@@ -163,8 +163,8 @@ sub _access_token_request {
             or ( $grant_type eq 'authorization_code' and ! defined( $url ) )
     ) {
         $dsl->status( 400 );
-        return $dsl->to_json(
-            {
+        return $dsl->send_as(
+            JSON => {
                 error             => 'invalid_request',
                 error_description => 'the request was missing one of: grant_type, '
                 . 'client_id, client_secret, code, redirect_uri;'
@@ -227,7 +227,7 @@ sub _access_token_request {
     $dsl->header( 'Pragma'        => 'no-cache' );
 
     $dsl->status( $status );
-    return $dsl->to_json( $json_response );
+    return $dsl->send_as( JSON => $json_response );
 }
 
 sub _verify_access_token_and_scope {

--- a/lib/Dancer2/Plugin/OAuth2/Server.pm
+++ b/lib/Dancer2/Plugin/OAuth2/Server.pm
@@ -223,8 +223,8 @@ sub _access_token_request {
         };
     }
 
-    $dsl->header( 'Cache-Control' => 'no-store' );
-    $dsl->header( 'Pragma'        => 'no-cache' );
+    $dsl->response_header( 'Cache-Control' => 'no-store' );
+    $dsl->response_header( 'Pragma'        => 'no-cache' );
 
     $dsl->status( $status );
     return $dsl->send_as( JSON => $json_response );


### PR DESCRIPTION
If an app using the plugin to protect routes using the `oauth_scopes` has a serializer set, then any JSON responses generated by the plugin are double-encoded. This MR switches to using `send_as JSON` rather than `to_json`, which prevents this double-encoding. This also requires a bump of the Dancer2 dependency to `0.200000`.

The MR also uses the `response_header` keyword for setting response headers, since use of the `header` keyword has been deprecated for some time.

I don't see these changes as conflicting with future changes as per #2, which I hope to start looking at later this year. No promises, as I've been hoping to get on with that since 2017 :grin:, but only now have a real world use case.